### PR TITLE
Fix permission check on service.html template

### DIFF
--- a/netbox_load_balancing/templates/netbox_load_balancing/assignments/service.html
+++ b/netbox_load_balancing/templates/netbox_load_balancing/assignments/service.html
@@ -9,12 +9,12 @@
     <h5 class="card-header">
         {% trans "LB Services" %}
         <div class="card-actions">
-            {% if perms.netbox_load_balancing.add_service %}
+            {% if perms.netbox_load_balancing.add_lbservice %}
                 <a href="{% url 'plugins:netbox_load_balancing:lbservice_add' %}?assigned_object_type={{ object|content_type_id }}&assigned_object_id={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-ghost-primary btn-sm">
                   <span class="mdi mdi-plus-thick" aria-hidden="true"></span> {% trans "Create LB Service" %}
                 </a>
             {% endif %}
-            {% if perms.netbox_load_balancing.add_serviceassignment %}
+            {% if perms.netbox_load_balancing.add_lbserviceassignment %}
                 <a href="{% url 'plugins:netbox_load_balancing:lbserviceassignment_add' %}?assigned_object_type={{ object|content_type_id }}&assigned_object_id={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-ghost-primary btn-sm">
                   <span class="mdi mdi-plus-thick" aria-hidden="true"></span> {% trans "Assign LB Service" %}
                 </a>


### PR DESCRIPTION
This PR is to fix an issue where the 'Create LB Service' button and the 'Assign LB Service' buttons are missing from the Virtual IP page. The do not show even when all plugin permission are granted. The buttons do show for an admin user.

Updated permission checks in the `service.html` template to use the correct permission names for load balancing services and assignments. This ensures that the "Create LB Service" and "Assign LB Service" buttons are only shown to users with the appropriate permissions.

Permission checks update:

* Changed permission checks from `add_service` and `add_serviceassignment` to `add_lbservice` and `add_lbserviceassignment` in the `netbox_load_balancing/templates/netbox_load_balancing/assignments/service.html` template.